### PR TITLE
Fix viewVerbose JS error

### DIFF
--- a/R/ggeditUI.R
+++ b/R/ggeditUI.R
@@ -17,7 +17,7 @@ ggEditUI <-function(id){
                  shiny::column(width=2,shiny::actionLink(ns('viewVerbose'),'View Layer Code'))
       ),
       shiny::hr(),
-      shiny::conditionalPanel(paste0('input.',ns('viewVerbose')),shiny::uiOutput(ns("SimPrint"))),
+      shiny::conditionalPanel(paste0('input["',ns('viewVerbose'),'"]'),shiny::uiOutput(ns("SimPrint"))),
       shiny::column(width=3,shiny::uiOutput(ns('activePlot'))),
       shiny::column(width=6,shiny::uiOutput(ns('layers'))),
       shiny::plotOutput(outputId = ns("Plot")),


### PR DESCRIPTION
Namespace separator is `-`, which is not allowed in JavaScript identifiers. Using
bracket notation solves this.